### PR TITLE
Fix compiler warning

### DIFF
--- a/Artnet.cpp
+++ b/Artnet.cpp
@@ -70,6 +70,7 @@ uint16_t Artnet::read()
       {
         return ART_POLL;
       }
+      return 0;
   }
   else
   {


### PR DESCRIPTION
Simple fix for a minor compiler warning.

    Artnet.cpp:78:1: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
